### PR TITLE
add file re-open example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ m = Map.from_iter(items, path="/tmp/map.fst")
 # 'clarence'
 matches = dict(m['clarence':])
 assert matches == {'clarence': 2, 'stevie': 3}
+
+# re-open a file you built previously with from_iter()
+m = Map(path='/path/to/existing.fst')
 ```
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,8 @@ Examples
           yield key, int(value)
     m = Map.from_iter( file_iterator('/your/input/file/'), '/your/mmapped/output.fst')
 
+    # re-open a file you built previously with from_iter()
+    m = Map(path='/path/to/existing.fst')
 
 API Reference
 -------------


### PR DESCRIPTION
It took me a few readings of the API-docs before I realised you can re-use a .fst file, instead of regenerating it all the time. To spare others the "d'oh" moment, another example to make it more obvious.

(This time, directly for both example locations, github README and readthedocs index.rst)