### PR TITLE
Initial attempt at efficient range queries across multiple Set objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ package.
 ## Status
 The package exposes almost all functionality of the `fst` crate, except for:
 
-- Combining the results of slicing, `search` and `search_re` with set operations
 - Using raw transducers
 
 
@@ -83,6 +82,24 @@ m = Map.from_iter( file_iterator('/your/input/file/'), '/your/mmapped/output.fst
 
 # re-open a file you built previously with from_iter()
 m = Map(path='/path/to/existing.fst')
+
+# slicing multiple sets efficiently
+a = Set.from_iter(["bar", "foo"])
+b = Set.from_iter(["baz", "foo"])
+list(UnionSet(a, b)['ba':'bb'])
+['bar', 'baz']
+
+# searching multiple sets efficiently
+a = Set.from_iter(["bar", "foo"])
+b = Set.from_iter(["baz", "foo"])
+list(UnionSet(a, b).search('ba', 1)
+['bar', 'baz']
+
+# searching multiple sets with a regex efficiently
+a = Set.from_iter(["bar", "foo"])
+b = Set.from_iter(["baz", "foo"])
+list(UnionSet(a, b).search_re(r'b\w{2}')
+['bar', 'baz']
 ```
 
 

--- a/rust/rust_fst.h
+++ b/rust/rust_fst.h
@@ -65,6 +65,7 @@ SetLevStream* fst_set_levsearch(Set*, Levenshtein*);
 SetRegexStream* fst_set_regexsearch(Set*, Regex*);
 SetOpBuilder* fst_set_make_opbuilder(Set*);
 SetOpBuilder* fst_set_make_opbuilder_streambuilder(SetStreamBuilder*);
+SetOpBuilder* fst_set_make_opbuilder_union(SetUnion*);
 void fst_set_free(Set*);
 
 char* fst_set_stream_next(SetStream*);
@@ -78,6 +79,7 @@ void fst_set_regexstream_free(SetRegexStream*);
 
 void fst_set_opbuilder_push(SetOpBuilder*, Set*);
 void fst_set_opbuilder_push_streambuilder(SetOpBuilder*, SetStreamBuilder*);
+void fst_set_opbuilder_push_union(SetOpBuilder*, SetUnion*);
 void fst_set_opbuilder_free(SetOpBuilder*);
 SetUnion* fst_set_opbuilder_union(SetOpBuilder*);
 SetIntersection* fst_set_opbuilder_intersection(SetOpBuilder*);

--- a/rust/rust_fst.h
+++ b/rust/rust_fst.h
@@ -64,6 +64,7 @@ SetStream* fst_set_stream(Set*);
 SetLevStream* fst_set_levsearch(Set*, Levenshtein*);
 SetRegexStream* fst_set_regexsearch(Set*, Regex*);
 SetOpBuilder* fst_set_make_opbuilder(Set*);
+SetOpBuilder* fst_set_make_opbuilder_streambuilder(SetStreamBuilder*);
 void fst_set_free(Set*);
 
 char* fst_set_stream_next(SetStream*);
@@ -76,6 +77,7 @@ char* fst_set_regexstream_next(SetRegexStream*);
 void fst_set_regexstream_free(SetRegexStream*);
 
 void fst_set_opbuilder_push(SetOpBuilder*, Set*);
+void fst_set_opbuilder_push_streambuilder(SetOpBuilder*, SetStreamBuilder*);
 void fst_set_opbuilder_free(SetOpBuilder*);
 SetUnion* fst_set_opbuilder_union(SetOpBuilder*);
 SetIntersection* fst_set_opbuilder_intersection(SetOpBuilder*);
@@ -97,6 +99,8 @@ void fst_set_symmetricdifference_free(SetSymmetricDifference*);
 
 SetStreamBuilder* fst_set_streambuilder_new(Set*);
 SetStreamBuilder* fst_set_streambuilder_add_ge(SetStreamBuilder*, char*);
+SetStreamBuilder* fst_set_streambuilder_add_gt(SetStreamBuilder*, char*);
+SetStreamBuilder* fst_set_streambuilder_add_le(SetStreamBuilder*, char*);
 SetStreamBuilder* fst_set_streambuilder_add_lt(SetStreamBuilder*, char*);
 SetStream* fst_set_streambuilder_finish(SetStreamBuilder*);
 

--- a/rust/rust_fst.h
+++ b/rust/rust_fst.h
@@ -66,6 +66,7 @@ SetRegexStream* fst_set_regexsearch(Set*, Regex*);
 SetOpBuilder* fst_set_make_opbuilder(Set*);
 SetOpBuilder* fst_set_make_opbuilder_streambuilder(SetStreamBuilder*);
 SetOpBuilder* fst_set_make_opbuilder_levstream(SetLevStream*);
+SetOpBuilder* fst_set_make_opbuilder_regexstream(SetRegexStream*);
 SetOpBuilder* fst_set_make_opbuilder_union(SetUnion*);
 void fst_set_free(Set*);
 
@@ -80,6 +81,7 @@ void fst_set_regexstream_free(SetRegexStream*);
 
 void fst_set_opbuilder_push(SetOpBuilder*, Set*);
 void fst_set_opbuilder_push_levstream(SetOpBuilder*, SetLevStream*);
+void fst_set_opbuilder_push_regexstream(SetOpBuilder*, SetRegexStream*);
 void fst_set_opbuilder_push_streambuilder(SetOpBuilder*, SetStreamBuilder*);
 void fst_set_opbuilder_push_union(SetOpBuilder*, SetUnion*);
 void fst_set_opbuilder_free(SetOpBuilder*);

--- a/rust/rust_fst.h
+++ b/rust/rust_fst.h
@@ -65,6 +65,7 @@ SetLevStream* fst_set_levsearch(Set*, Levenshtein*);
 SetRegexStream* fst_set_regexsearch(Set*, Regex*);
 SetOpBuilder* fst_set_make_opbuilder(Set*);
 SetOpBuilder* fst_set_make_opbuilder_streambuilder(SetStreamBuilder*);
+SetOpBuilder* fst_set_make_opbuilder_levstream(SetLevStream*);
 SetOpBuilder* fst_set_make_opbuilder_union(SetUnion*);
 void fst_set_free(Set*);
 
@@ -78,6 +79,7 @@ char* fst_set_regexstream_next(SetRegexStream*);
 void fst_set_regexstream_free(SetRegexStream*);
 
 void fst_set_opbuilder_push(SetOpBuilder*, Set*);
+void fst_set_opbuilder_push_levstream(SetOpBuilder*, SetLevStream*);
 void fst_set_opbuilder_push_streambuilder(SetOpBuilder*, SetStreamBuilder*);
 void fst_set_opbuilder_push_union(SetOpBuilder*, SetUnion*);
 void fst_set_opbuilder_free(SetOpBuilder*);

--- a/rust/src/set.rs
+++ b/rust/src/set.rs
@@ -155,6 +155,14 @@ pub extern "C" fn fst_set_make_opbuilder_levstream(ptr: *mut SetLevStream) -> *m
 }
 
 #[no_mangle]
+pub extern "C" fn fst_set_make_opbuilder_regexstream(ptr: *mut SetRegexStream) -> *mut set::OpBuilder<'static> {
+    let srs = val_from_ptr!(ptr);
+    let mut ob = set::OpBuilder::new();
+    ob.push(srs.into_stream());
+    to_raw_ptr(ob)
+}
+
+#[no_mangle]
 pub extern "C" fn fst_set_make_opbuilder_streambuilder(ptr: *mut set::StreamBuilder<'static>) -> *mut set::OpBuilder<'static> {
     let sb = val_from_ptr!(ptr);
     let mut ob = set::OpBuilder::new();
@@ -182,6 +190,13 @@ pub extern "C" fn fst_set_opbuilder_push_levstream(ptr: *mut set::OpBuilder<'sta
     let sls = val_from_ptr!(sls_ptr);
     let ob = mutref_from_ptr!(ptr);
     ob.push(sls.into_stream());
+}
+
+#[no_mangle]
+pub extern "C" fn fst_set_opbuilder_push_regexstream(ptr: *mut set::OpBuilder<'static>, srs_ptr: *mut SetRegexStream) {
+    let srs = val_from_ptr!(srs_ptr);
+    let ob = mutref_from_ptr!(ptr);
+    ob.push(srs.into_stream());
 }
 
 #[no_mangle]

--- a/rust/src/set.rs
+++ b/rust/src/set.rs
@@ -147,10 +147,25 @@ pub extern "C" fn fst_set_make_opbuilder(ptr: *mut Set) -> *mut set::OpBuilder<'
 make_free_fn!(fst_set_opbuilder_free, *mut set::OpBuilder);
 
 #[no_mangle]
+pub extern "C" fn fst_set_make_opbuilder_streambuilder(ptr: *mut set::StreamBuilder<'static>) -> *mut set::OpBuilder<'static> {
+    let sb = val_from_ptr!(ptr);
+    let mut ob = set::OpBuilder::new();
+    ob.push(sb.into_stream());
+    to_raw_ptr(ob)
+}
+
+#[no_mangle]
 pub extern "C" fn fst_set_opbuilder_push(ptr: *mut set::OpBuilder, set_ptr: *mut Set) {
     let set = ref_from_ptr!(set_ptr);
     let ob = mutref_from_ptr!(ptr);
     ob.push(set);
+}
+
+#[no_mangle]
+pub extern "C" fn fst_set_opbuilder_push_streambuilder(ptr: *mut set::OpBuilder<'static>, sb_ptr: *mut set::StreamBuilder<'static>) {
+    let sb = val_from_ptr!(sb_ptr);
+    let ob = mutref_from_ptr!(ptr);
+    ob.push(sb.into_stream());
 }
 
 #[no_mangle]
@@ -203,6 +218,22 @@ pub extern "C" fn fst_set_streambuilder_add_ge(ptr: *mut set::StreamBuilder<'sta
                                                -> *mut set::StreamBuilder<'static> {
     let sb = val_from_ptr!(ptr);
     to_raw_ptr(sb.ge(cstr_to_str(c_bound)))
+}
+
+#[no_mangle]
+pub extern "C" fn fst_set_streambuilder_add_gt(ptr: *mut set::StreamBuilder<'static>,
+                                               c_bound: *mut libc::c_char)
+                                               -> *mut set::StreamBuilder<'static> {
+    let sb = val_from_ptr!(ptr);
+    to_raw_ptr(sb.gt(cstr_to_str(c_bound)))
+}
+
+#[no_mangle]
+pub extern "C" fn fst_set_streambuilder_add_le(ptr: *mut set::StreamBuilder<'static>,
+                                               c_bound: *mut libc::c_char)
+                                               -> *mut set::StreamBuilder<'static> {
+    let sb = val_from_ptr!(ptr);
+    to_raw_ptr(sb.le(cstr_to_str(c_bound)))
 }
 
 #[no_mangle]

--- a/rust/src/set.rs
+++ b/rust/src/set.rs
@@ -147,6 +147,14 @@ pub extern "C" fn fst_set_make_opbuilder(ptr: *mut Set) -> *mut set::OpBuilder<'
 make_free_fn!(fst_set_opbuilder_free, *mut set::OpBuilder);
 
 #[no_mangle]
+pub extern "C" fn fst_set_make_opbuilder_levstream(ptr: *mut SetLevStream) -> *mut set::OpBuilder<'static> {
+    let sls = val_from_ptr!(ptr);
+    let mut ob = set::OpBuilder::new();
+    ob.push(sls.into_stream());
+    to_raw_ptr(ob)
+}
+
+#[no_mangle]
 pub extern "C" fn fst_set_make_opbuilder_streambuilder(ptr: *mut set::StreamBuilder<'static>) -> *mut set::OpBuilder<'static> {
     let sb = val_from_ptr!(ptr);
     let mut ob = set::OpBuilder::new();
@@ -167,6 +175,13 @@ pub extern "C" fn fst_set_opbuilder_push(ptr: *mut set::OpBuilder, set_ptr: *mut
     let set = ref_from_ptr!(set_ptr);
     let ob = mutref_from_ptr!(ptr);
     ob.push(set);
+}
+
+#[no_mangle]
+pub extern "C" fn fst_set_opbuilder_push_levstream(ptr: *mut set::OpBuilder<'static>, sls_ptr: *mut SetLevStream) {
+    let sls = val_from_ptr!(sls_ptr);
+    let ob = mutref_from_ptr!(ptr);
+    ob.push(sls.into_stream());
 }
 
 #[no_mangle]

--- a/rust/src/set.rs
+++ b/rust/src/set.rs
@@ -155,6 +155,14 @@ pub extern "C" fn fst_set_make_opbuilder_streambuilder(ptr: *mut set::StreamBuil
 }
 
 #[no_mangle]
+pub extern "C" fn fst_set_make_opbuilder_union(ptr: *mut set::Union<'static>) -> *mut set::OpBuilder<'static> {
+    let union = val_from_ptr!(ptr);
+    let mut ob = set::OpBuilder::new();
+    ob.push(union.into_stream());
+    to_raw_ptr(ob)
+}
+
+#[no_mangle]
 pub extern "C" fn fst_set_opbuilder_push(ptr: *mut set::OpBuilder, set_ptr: *mut Set) {
     let set = ref_from_ptr!(set_ptr);
     let ob = mutref_from_ptr!(ptr);
@@ -166,6 +174,13 @@ pub extern "C" fn fst_set_opbuilder_push_streambuilder(ptr: *mut set::OpBuilder<
     let sb = val_from_ptr!(sb_ptr);
     let ob = mutref_from_ptr!(ptr);
     ob.push(sb.into_stream());
+}
+
+#[no_mangle]
+pub extern "C" fn fst_set_opbuilder_push_union(ptr: *mut set::OpBuilder<'static>, union_ptr: *mut set::Union<'static>) {
+    let union = val_from_ptr!(union_ptr);
+    let ob = mutref_from_ptr!(ptr);
+    ob.push(union.into_stream());
 }
 
 #[no_mangle]

--- a/rust_fst/__init__.py
+++ b/rust_fst/__init__.py
@@ -1,4 +1,4 @@
-from .set import Set
+from .set import Set, UnionSet
 from .map import Map
 
-__all__ = ["Set", "Map"]
+__all__ = ["Set", "UnionSet", "Map"]

--- a/rust_fst/set.py
+++ b/rust_fst/set.py
@@ -467,10 +467,9 @@ class UnionSet(object):
         if s.start and s.stop and s.start > s.stop:
             raise ValueError(
                 "Start key must be lexicographically smaller than stop.")
-        if len(self.sets) <= 1:
-            raise ValueError(
-                "Must have more than one set to operate on.")
 
+        if not self.sets:
+            return
         opbuilder = OpBuilder.from_slice(self.sets[0]._ptr, s)
         streams = []
         for fst in self.sets[1:]:
@@ -483,9 +482,8 @@ class UnionSet(object):
     def __iter__(self):
         """ Get an iterator over all keys in all sets in lexicographical order.
         """
-        if len(self.sets) <= 1:
-            raise ValueError(
-                "Must have more than one set to operate on.")
+        if not self.sets:
+            return
         opbuilder = OpBuilder(self.sets[0]._ptr,
                               input_type=OpBuilderInputType.SET)
         for fst in self.sets[1:]:
@@ -494,12 +492,11 @@ class UnionSet(object):
 
     def _make_opbuilder(self, *others):
         others = list(others)
-        if len(self.sets) <= 1:
-            raise ValueError(
-                "Must have more than one set to operate on.")
         if not others:
             raise ValueError(
                 "Must have at least one set to compare against.")
+        if not self.sets:
+            return
         our_opbuilder = OpBuilder(self.sets[0]._ptr,
                                   input_type=OpBuilderInputType.SET)
         for fst in self.sets[1:]:
@@ -544,9 +541,8 @@ class UnionSet(object):
         :returns:           Iterator over matching values in the set
         :rtype:             :py:class:`KeyStreamIterator`
         """
-        if len(self.sets) <= 1:
-            raise ValueError(
-                "Must have more than one set to operate on.")
+        if not self.sets:
+            return
         opbuilder = OpBuilder.from_search(self.sets[0], term, max_dist)
         for fst in self.sets[1:]:
             opbuilder.push(_build_levsearch(fst, term, max_dist))
@@ -576,9 +572,8 @@ class UnionSet(object):
         :returns:           An iterator over all matching keys in the set
         :rtype:             :py:class:`KeyStreamIterator`
         """
-        if len(self.sets) <= 1:
-            raise ValueError(
-                "Must have more than one set to operate on.")
+        if not self.sets:
+            return
         opbuilder = OpBuilder.from_search_re(self.sets[0], pattern)
         for fst in self.sets[1:]:
             opbuilder.push(_build_research(fst, pattern))

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -195,6 +195,11 @@ def test_unionset_range(fst_unionset):
         fst_unionset['c']
 
 
+def test_unionset_search(fst_unionset):
+    matches = list(fst_unionset.search("bam", 1))
+    assert matches == ["bap", "bar", "baz"]
+
+
 def test_unionset_symmetric_difference():
     a = Set.from_iter(["bar", "foo"])
     b = Set.from_iter(["baz", "foo"])

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -200,6 +200,11 @@ def test_unionset_search(fst_unionset):
     assert matches == ["bap", "bar", "baz"]
 
 
+def test_unionset_search_re(fst_unionset):
+    matches = list(fst_unionset.search_re(r'ba.*'))
+    assert matches == ["bap", "bar", "baz"]
+
+
 def test_unionset_symmetric_difference():
     a = Set.from_iter(["bar", "foo"])
     b = Set.from_iter(["baz", "foo"])

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -166,6 +166,20 @@ def test_unionset_contains(fst_unionset):
         assert key in fst_unionset
 
 
+def test_unionset_difference():
+    a = Set.from_iter(["bar", "foo"])
+    b = Set.from_iter(["baz", "foo"])
+    c = Set.from_iter(["bonk", "foo"])
+    assert list(UnionSet(a, b).difference(c)) == ["bar", "baz"]
+
+
+def test_unionset_intersection():
+    a = Set.from_iter(["bar", "foo"])
+    b = Set.from_iter(["baz", "foo"])
+    c = Set.from_iter(["bonk", "foo"])
+    assert list(UnionSet(a, b).intersection(c)) == ["foo"]
+
+
 def test_unionset_iter(fst_unionset):
     stored_keys = list(fst_unionset)
     assert stored_keys == sorted(set(TEST_KEYS+TEST_KEYS2))
@@ -179,3 +193,17 @@ def test_unionset_range(fst_unionset):
         fst_unionset['c':'a']
     with pytest.raises(ValueError):
         fst_unionset['c']
+
+
+def test_unionset_symmetric_difference():
+    a = Set.from_iter(["bar", "foo"])
+    b = Set.from_iter(["baz", "foo"])
+    c = Set.from_iter(["bonk", "foo"])
+    assert list(UnionSet(a, b).symmetric_difference(c)) == ["bar", "baz", "bonk"]
+
+
+def test_unionset_union():
+    a = Set.from_iter(["bar", "foo"])
+    b = Set.from_iter(["baz", "foo"])
+    c = Set.from_iter(["bonk", "foo"])
+    assert list(UnionSet(a, b).union(c)) == ["bar", "baz", "bonk", "foo"]


### PR DESCRIPTION
This is not compiling yet (using rustc 1.24.0-nightly (0a3761e63 2018-01-03)):

  ```
(dblewett)Wed Jan 10, 10:03 | /home/dblewett/src/python-rust-fst/fstwrapper
rusty% cargo build          
   Compiling fst-wrapper v0.3.0 (file:///home/dblewett/src/python-rust-fst/fstwrapper)
error[E0277]: the trait bound `for<'a> &fst::set::Stream<'_>: fst::Streamer<'a>` is not satisfied
   --> src/set.rs:152:36
    |
152 |     let ob = set::OpBuilder::new().add(stream);
    |                                    ^^^ the trait `for<'a> fst::Streamer<'a>` is not implemented for `&fst::set::Stream<'_>`
    |
    = help: the following implementations were found:
              <fst::set::Stream<'s, A> as fst::Streamer<'a>>

error[E0277]: the trait bound `for<'a> &fst::set::Stream<'_>: fst::Streamer<'a>` is not satisfied
   --> src/set.rs:168:8
    |
168 |     ob.push(stream);
    |        ^^^^ the trait `for<'a> fst::Streamer<'a>` is not implemented for `&fst::set::Stream<'_>`
    |
    = help: the following implementations were found:
              <fst::set::Stream<'s, A> as fst::Streamer<'a>>

error: aborting due to 2 previous errors

error: Could not compile `fst-wrapper`.
```